### PR TITLE
Add previous/next navigation scoped to each blog section

### DIFF
--- a/_includes/post_nav.html
+++ b/_includes/post_nav.html
@@ -1,0 +1,37 @@
+{% comment %}
+  Previous/next navigation scoped to the current post's section.
+  A "section" is the (lang, type) pair from the post's front matter.
+  site.posts is newest-first, so index-1 is the newer post and
+  index+1 is the older post. Prev = older, Next = newer.
+{% endcomment %}
+
+{% assign section_posts = site.posts | where: "lang", page.lang | where: "type", page.type %}
+
+{% assign current_index = nil %}
+{% for post in section_posts %}
+  {% if post.url == page.url %}
+    {% assign current_index = forloop.index0 %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
+{% if current_index %}
+  {% assign newer_index = current_index | minus: 1 %}
+  {% assign older_index = current_index | plus: 1 %}
+
+  {% assign newer_post = nil %}
+  {% assign older_post = nil %}
+  {% if newer_index >= 0 %}{% assign newer_post = section_posts[newer_index] %}{% endif %}
+  {% if older_index < section_posts.size %}{% assign older_post = section_posts[older_index] %}{% endif %}
+
+  {% if older_post or newer_post %}
+    <nav class="post-nav">
+      <span class="post-nav-prev">
+        {% if older_post %}<a href="{{ older_post.url }}" rel="prev">&larr; {{ older_post.title }}</a>{% endif %}
+      </span>
+      <span class="post-nav-next">
+        {% if newer_post %}<a href="{{ newer_post.url }}" rel="next">{{ newer_post.title }} &rarr;</a>{% endif %}
+      </span>
+    </nav>
+  {% endif %}
+{% endif %}

--- a/_includes/style.html
+++ b/_includes/style.html
@@ -104,6 +104,17 @@
         margin: 0.5rem 0 1.5rem 0;
     }
 
+    .post-nav {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        margin: 2rem 0 1.5rem 0;
+    }
+
+    .post-nav-next {
+        text-align: right;
+    }
+
     /* Podcast Audio Controls */
     .audio-player {
         width: 100%;

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,6 +37,8 @@ layout: default
 
   {{ content }}
 
+  {% include post_nav.html %}
+
   {% include breadcrumbs.html %}
 </div>
 


### PR DESCRIPTION
## Summary
Adds Previous/Next links to each post, scoped to its own section.

Because every post (across languages and types) lives in Jekyll's single `site.posts` collection, the built-in `page.previous`/`page.next` mix sections together (a Tamil poem's "next" could be an English podcast). This filters by the `(lang, type)` front-matter pair you already use for section listings.

## Changes
- **`_includes/post_nav.html`** (new) — filters `site.posts` to the current post's `lang` + `type`, finds its position, and links to the older post (**Prev ←**) and newer post (**Next →**) within that section. Link text is the neighbor's `title`, href is its `url`.
- **`_layouts/post.html`** — includes `post_nav.html` after the content, before the breadcrumbs.
- **`_includes/style.html`** — adds `.post-nav` styling (prev left, next right).

## Behavior
- Covers every section automatically (english/blog, tamil/blog, tamil/a400, tamil/podcast, english/podcast) — keyed purely off `lang` + `type`, no per-post config.
- Newest post in a section shows only Prev; oldest shows only Next (guards against Ruby negative-index wraparound).
- Pure Liquid — works on default GitHub Pages, no plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)