### PR TITLE
Add rel=me link for Webmention authentication

### DIFF
--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -1,8 +1,8 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon">
-<title>{{ page.title }}</title>
+<link rel="stylesheet" href="/assets/style.css" />
 <link href="{{ site.github }}" rel="me">
+<title>{{ page.title }}</title>
 
 {% seo title=false %}
-

--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -2,5 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon">
 <title>{{ page.title }}</title>
+<link href="{{ site.github }}" rel="me">
 
 {% seo title=false %}
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,6 @@
     <head>
         {% include metadata.html %}
         {% include rss.html lang=page.lang type=page.type %}
-        <link rel="stylesheet" href="/assets/style.css" />
     </head>
     <body>
         {{ content }}


### PR DESCRIPTION
This PR adds a rel=me link targeting the GitHub profile of the owner, powered by the site.github configuration variable in _config.yml. This is used to authenticate the site's ownership on webmention.io.